### PR TITLE
Fix bug in list command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -11,6 +11,11 @@ import seedu.address.model.Model;
 public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
+    
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Lists all users.\n"
+            + "There should be no parameters!\n"
+            + "Example: " + COMMAND_WORD;
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -69,7 +69,7 @@ public class AddressBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(userInput);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+public class ListCommandParser implements Parser<ListCommand> {
+    /**
+     * 
+     * @param userInput
+     * @throws ParseException
+     */
+    public ListCommand parse(String userInput) throws ParseException {
+        String[] words = userInput.split(" ");
+        if (words.length != 1) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+        } else {
+            return new ListCommand();
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -8,9 +7,12 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 public class ListCommandParser implements Parser<ListCommand> {
     /**
-     * 
-     * @param userInput
-     * @throws ParseException
+     * Parses the given user input and creates a ListCommand object.
+     *
+     * @param userInput the input string provided by the user.
+     * @throws ParseException if the user input is not in the expected format
+     *                        or if it contains unexpected arguments.
+     * @return a ListCommand object.
      */
     public ListCommand parse(String userInput) throws ParseException {
         String[] words = userInput.split(" ");


### PR DESCRIPTION
In AddressBookParser class, the list command does not check if there are any additonal arguments after the command "list". As such, the students' details would be successfully listed if user input was something like "list all"

Let's add a ListCommmandParser class to check if the user input is valid for the list command (ie. just the word "list"). Else, TP will send a message to user telling the user of the correct format
